### PR TITLE
ListUsers.edit() and ListUsers.remove() now also use...

### DIFF
--- a/pyolite/models/lists/users.py
+++ b/pyolite/models/lists/users.py
@@ -53,7 +53,7 @@ class ListUsers(object):
 
     self.repo.replace(pattern, string)
 
-    self.repo.git.commit(['conf'],
+    self.repository_model.git.commit(['conf'],
                          "User %s has %s permission for repository %s" %
                          (user.name, permission, self.repository_model.name))
     return user
@@ -63,7 +63,7 @@ class ListUsers(object):
     pattern = r'(\s*)([RW+DC]*)(\s*)=(\s*)%s' % user.name
     self.repo.replace(pattern, "")
 
-    self.repo.git.commit(['conf'],
+    self.repository_model.git.commit(['conf'],
                          "Deleted user %s from repository %s" %
                          (user.name, self.repository_model.name))
 


### PR DESCRIPTION
self.repository_model.git.commit() instead of self.repo.git.commit()

Hey,

thanks for this great module! 
I had an issue when removing users from repositories:

    ...
        repo.users.remove(user.username)
      File "/usr/local/lib/python2.7/dist-packages/pyolite/models/lists/users.py", line 25, in decorated
        return func(self, user, *args, **kwargs)
      File "/usr/local/lib/python2.7/dist-packages/pyolite/models/lists/users.py", line 66, in remove
        self.repository_model.commit(['conf'],
    AttributeError: 'Repository' object has no attribute 'commit'

this commit fixes this.

Best regards,
morla