### PR TITLE
add permission&user existence check before editing repo's configuration

### DIFF
--- a/pyolite/models/lists/users.py
+++ b/pyolite/models/lists/users.py
@@ -48,6 +48,15 @@ class ListUsers(object):
 
     @with_user
     def edit(self, user, permission):
+        if user.name not in self.repo.users:
+            raise ValueError('User %s not exists in repo %s' %
+                             (user.name, self.repository_model.name))
+
+        if set(map(lambda permission: permission.upper(), permission)) - \
+                ACCEPTED_PERMISSIONS != set([]):
+            raise ValueError('Invalid permissions. They must be from %s' %
+                             ACCEPTED_PERMISSIONS)
+
         pattern = r'(\s*)([RW+DC]*)(\s*)=(\s*)%s' % user.name
         string = r"\n    %s    =    %s" % (permission, user.name)
 
@@ -94,19 +103,19 @@ class ListUsers(object):
         )
         self.repository_model.git.commit(['conf'], commit_message)
 
-    def __iter__(self):
-        for user in self._user:
-            yield user
+    # def __iter__(self):
+    #     for user in self._user:
+    #         yield user
 
-    def __getitem__(self, item):
-        return self._users[item]
+    # def __getitem__(self, item):
+    #     return self._users[item]
 
-    def __setitem__(self, item, value):
-        self._users[item] = value
+    # def __setitem__(self, item, value):
+    #     self._users[item] = value
 
-    def __add__(self, items):
-        for item in items:
-            self.append(item)
+    # def __add__(self, items):
+    #     for item in items:
+    #         self.append(item)
 
     def __str__(self):
         return "['%s']" % ', '.join(self.repo.users)


### PR DESCRIPTION
hi,
first of all, I want to thank you for your excellent work, so that I can manipulate gitolite with Python without writing much code myself.

but when I prepare to edit the user permission configuration of a repo, if the use not exists in the repo's config file, pyolite did nothing, and if the user exists, it will update the configuration file without persmission argument check. So I add user existence check and permission argument check before updating the repo's configuration.

Also I found that these attribute: `_user`，`_users` and this method `append` are not exists in `ListUsers` class, and I don't konw if you're preparing to maintain these code in the future and what is your plan for this class , so I just treat them as bugs and comment them out.

B.R.
thanks.